### PR TITLE
Simplify .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,2 @@
-# Compiled class file
-*.class
-
-# Log file
-*.log
-
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
+# Maven build results
+/target/


### PR DESCRIPTION
In a Maven-based project all build results can be excluded by excluding
/target/. Files which are not produced during the build (including
tests) don't need to be added. It's more elegant to exclude
IDE-specific files in .git/info/exclude and not share them.